### PR TITLE
Add option to ignore paddings and label borders

### DIFF
--- a/index.html
+++ b/index.html
@@ -255,6 +255,14 @@
             </div>
           </div>
 
+          <div class="control-group">
+            <label class="toggle-switch" style="justify-content: flex-start; gap: 10px;">
+              <input type="checkbox" id="paddingIgnoreCheckbox">
+              <span class="slider"></span>
+              <span>Ignore padding</span>
+            </label>
+          </div>
+
           <div id="qr-controls-group" class="control-group"
             style="display: none; flex-direction: column; gap: var(--spacing-md);">
             <!-- Type Selector -->

--- a/js/fabric_editor.js
+++ b/js/fabric_editor.js
@@ -2,6 +2,7 @@ let canvas;
 let fontSizeInput;
 let fontFamilyInput;
 let ditheringAlgorithmSelect; // New reference
+let paddingIgnoreCheckbox;
 
 // Padding state (in pixels)
 let paddingState = {
@@ -34,6 +35,7 @@ document.addEventListener("DOMContentLoaded", () => {
   fontSizeInput = document.getElementById('fontSize');
   fontFamilyInput = document.getElementById('fontFamilyInput');
   ditheringAlgorithmSelect = document.getElementById('ditheringAlgorithmSelect'); // Initialize new reference
+  paddingIgnoreCheckbox = document.getElementById('paddingIgnoreCheckbox');
 
   // QR Code content input event listener
   const qrContentInput = document.getElementById('qrContentInput');
@@ -231,6 +233,8 @@ document.addEventListener("DOMContentLoaded", () => {
       }
     }
 
+    if (arePaddingsIgnored()) return;
+
     // Update cached bounding box
     obj.setCoords();
 
@@ -263,6 +267,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // Constrain object movement to stay within padding bounds
   canvas.on('object:moving', (e) => {
+    if (arePaddingsIgnored()) return;
     constrainObjectToCanvas(e.target);
   });
 
@@ -371,6 +376,10 @@ function constrainObjectToCanvas(obj) {
   obj.left += newLeft - objBBox.left;
   obj.top += newTop - objBBox.top;
   obj.setCoords();
+}
+
+function arePaddingsIgnored() {
+  return paddingIgnoreCheckbox ? paddingIgnoreCheckbox.checked : false;
 }
 
 function removeEmptyTextObjects(e) {

--- a/js/ui.js
+++ b/js/ui.js
@@ -559,6 +559,8 @@ document.addEventListener("DOMContentLoaded", () => {
     const paddingLeftInput = document.getElementById('paddingLeft');
     const paddingRightInput = document.getElementById('paddingRight');
 
+    const paddingIgnoreCheckbox = document.getElementById("paddingIgnoreCheckbox");
+
     // Check for URL parameters
     const urlParams = new URLSearchParams(window.location.search);
     const urlPrinter = urlParams.get('printer');
@@ -569,6 +571,7 @@ document.addEventListener("DOMContentLoaded", () => {
     const urlPaddingBottom = urlParams.get('paddingBottom');
     const urlPaddingLeft = urlParams.get('paddingLeft');
     const urlPaddingRight = urlParams.get('paddingRight');
+    const urlPaddingIgnore = urlParams.get('paddingIgnore') === 'true';
 
     if (urlPrinter !== null && urlWidth !== null && urlHeight !== null) {
       // Apply settings from URL
@@ -607,6 +610,8 @@ document.addEventListener("DOMContentLoaded", () => {
       // No URL params, show modal
       startupModal.classList.add("show");
     }
+
+    if (paddingIgnoreCheckbox) paddingIgnoreCheckbox.checked = urlPaddingIgnore;
 
     if (settingsBtn) {
       settingsBtn.addEventListener("click", () => {
@@ -701,6 +706,13 @@ document.addEventListener("DOMContentLoaded", () => {
     if (paddingRightInput) {
       paddingRightInput.addEventListener('change', updatePaddingFromInputs);
       paddingRightInput.addEventListener('blur', updatePaddingFromInputs);
+    }
+    if (paddingIgnoreCheckbox) {
+      paddingIgnoreCheckbox.addEventListener('change', () => {
+        const newUrl = new URL(window.location);
+        newUrl.searchParams.set('paddingIgnore', paddingIgnoreCheckbox.checked);
+        window.history.replaceState({}, '', newUrl);
+      });
     }
 
     // 3. Handle Start Button Click


### PR DESCRIPTION
First part of #13: Allow objects to move outside of canvas by disabling the edge constraints on request. Right now it is difficult to use because the control handles disappear outside of the canvas and objects can get lost or hard to recover.

Fixes #13.