### PR TITLE
Fit label length to content

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,6 +125,11 @@
             <input type="number" id="heightInput" class="dimension-input" step="0.1" min="1" />
             <span class="dimension-unit">mm</span>
           </div>
+          <div class="dimension-input-group">
+            <button id="fitContentBtn" class="btn" title="Fit to content">
+              Fit to content
+            </button>
+          </div>
         </div>
 
         <!-- General Controls -->

--- a/js/fabric_editor.js
+++ b/js/fabric_editor.js
@@ -1177,7 +1177,33 @@ window.fabricEditor = {
 
   getPaddingBounds: function () {
     return getPaddingBounds();
-  }
+  },
+
+  fitContent: function () {
+    if (!canvas) return;
+
+    const objs = canvas.getObjects();
+    if (!objs.length) return;
+
+    let min = Number.MAX_VALUE;
+    let max = Number.MIN_VALUE;
+    objs.forEach((obj) => {
+      if (obj.paddingGuide) return;
+      obj.setCoords();
+      const bbox = obj.getBoundingRect();
+      min = Math.min(min, bbox.left);
+      max = Math.max(max, bbox.left+bbox.width);
+    });
+
+    const offset = min - paddingState.left;
+    objs.forEach((obj) => {
+      if (obj.paddingGuide) return;
+      obj.left -= offset;
+      obj.setCoords();
+    });
+
+    this.updateCanvasSize(max - min + paddingState.left + paddingState.right, canvas.getHeight());
+  },
 };
 
 // Helper function to get padding bounds in pixels

--- a/js/ui.js
+++ b/js/ui.js
@@ -495,6 +495,15 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   }
 
+  const fitContentBtn = document.getElementById("fitContentBtn");
+  if (fitContentBtn) {
+    fitContentBtn.addEventListener("click", () => {
+      if (!window.fabricEditor) return;
+      window.fabricEditor.fitContent();
+      updatePreview();
+    });
+  }
+
   if (startupModal && printerSelect && startBtn) {
     // 1. Populate Printer List
     if (typeof supportedPrinters !== 'undefined') {


### PR DESCRIPTION
UI is far from being perfect and I'd prefer a bit less coupling between all these functions and classes.

TODO:
- [ ] Show only in infinite mode
- [ ] Improve UI
- [ ] Add toggle switch to crop automatically (step towards #5)
- [ ] Limit to visible content. Currently the full bounding box is used, even if parts are outside of the canvas.

Fixes #8.